### PR TITLE
Rename "Group Ability Check" to "Group Saving Throw / Ability Check"

### DIFF
--- a/main.js
+++ b/main.js
@@ -154,7 +154,7 @@ Hooks.on('getSceneControlButtons', controls => {
                 },
                 {
                     name: "ability",
-                    title: game.system.id === "pf2e" ? "Group Saving Throw" : "Group Ability Check",
+                    title: game.system.id === "pf2e" ? "Group Saving Throw" : "Group Saving Throw / Ability Check",
                     icon: "fas fa-user-shield",
                     visible: game.user.isGM,
                     onClick: () => {

--- a/module/apps.js
+++ b/module/apps.js
@@ -423,7 +423,7 @@ export class GroupAbilityCheck extends GroupRollApp {
     static get defaultOptions() {
         const options = super.defaultOptions;
         options.id = "group-ability-check";
-        options.title = "Group Ability Check";
+        options.title = "Group Saving Throw / Ability Check";
         options.template = "modules/grouproll/templates/group-ability-check.html";
         return options;
     }


### PR DESCRIPTION
Rename the "Group Ability Check" tooltip and window title to "Group Saving Throw / Ability Check".

I rarely use group ability checks, but frequently use group saving throws, and this makes it easier to find the right button on the toolbar.